### PR TITLE
(feat) added liquibase migration inside Docker container creation

### DIFF
--- a/wildfly/unifiedpush-wildfly/Dockerfile
+++ b/wildfly/unifiedpush-wildfly/Dockerfile
@@ -2,14 +2,32 @@
 FROM aerogear/wildfly
 MAINTAINER Bruno Oliveira <bruno@aerogear.org>
 
+
+# Download Aerogear distribution
+ENV UPSVER=1.1.1.Final
+ENV UPSDIST=/opt/aerogear-unifiedpush-server-$UPSVER
+
+RUN curl -L -o /opt/aerogear-unifiedpush-server-$UPSVER-dist.tar.gz https://github.com/aerogear/aerogear-unifiedpush-server/releases/download/$UPSVER/aerogear-unifiedpush-server-$UPSVER-dist.tar.gz
+WORKDIR /opt
+RUN tar zxf aerogear-unifiedpush-server-$UPSVER-dist.tar.gz
+
+# unzip migrator and copy liquibase.properties
+WORKDIR $UPSDIST/migrator
+RUN unzip ups-migrator-dist.zip
+COPY liquibase.properties  $UPSDIST/migrator/ups-migrator/
+
 # Run everything below as aerogear user
 USER jboss
 
 # Switch to the working dir $JBOSS_HOME/standalone/deployments
 WORKDIR /opt/jboss/wildfly/standalone/deployments
 
-# Download binary file for the auth-server with Keycloak
-RUN curl -o auth-server.war https://repository.jboss.org/nexus/content/repositories/public-jboss/org/jboss/aerogear/unifiedpush/unifiedpush-auth-server/1.1.0-beta.2/unifiedpush-auth-server-1.1.0-beta.2.war
+# copy war files
+RUN   cp $UPSDIST/servers/unifiedpush-auth-server.war $JBOSS_HOME/standalone/deployments \
+      && cp $UPSDIST/servers/unifiedpush-server-wildfly.war $JBOSS_HOME/standalone/deployments
 
-# Download binary file for the UnifiedPush server
-RUN curl -o ag-push.war https://repository.jboss.org/nexus/content/repositories/public-jboss/org/jboss/aerogear/unifiedpush/unifiedpush-server-wildfly/1.1.0-beta.2/unifiedpush-server-wildfly-1.1.0-beta.2.war
+
+# copy and run startup script
+# migration is done inside the startup script before launching the server
+COPY entrypoint.sh /opt/
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/wildfly/unifiedpush-wildfly/entrypoint.sh
+++ b/wildfly/unifiedpush-wildfly/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+# run migrator
+echo "Starting Liquibase migration"
+cd $UPSDIST/migrator/ups-migrator
+./bin/ups-migrator update
+
+# launch wildfly
+exec /opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 $@

--- a/wildfly/unifiedpush-wildfly/liquibase.properties
+++ b/wildfly/unifiedpush-wildfly/liquibase.properties
@@ -1,0 +1,5 @@
+url=jdbc:mysql://unifiedpush:3306/unifiedpush
+driver=com.mysql.jdbc.Driver
+username=unifiedpush
+password=unifiedpush
+changeLogFile=liquibase/master.xml


### PR DESCRIPTION
Objective is to include the liquibase migrator process inside the docker container launch.
No change at the upper wildfly level.   
Has been tested with 1.1.1 Final   
Theory is that modifiying only the ENV UPSVER in the DockerFile should manage version update.   
Does not totally work today, partly because I am not sure about the naming convention : I have assumed that every release will be consistently labeled with a 1.1.x.Final when it get out of pre-release (like 1.1.2 currently), partly because there is inconsistency in the way the migrator zip archive is named in the releases between 1.1.0 and 1.1.1 for example.   
Resulting 1.1.1 image is currently being pushed to the public docker hub repo yvnicolas/aerogear-unifiedpush