### PR TITLE
RHMAP-6647 - Tweaks for OSE template

### DIFF
--- a/wildfly/configuration/xml/standalone-full-sample.xml
+++ b/wildfly/configuration/xml/standalone-full-sample.xml
@@ -153,11 +153,11 @@
                     </security>
                 </datasource>
                 <datasource jndi-name="java:jboss/datasources/UnifiedPushDS" enabled="true" use-java-context="true" pool-name="UnifiedPushDS" use-ccm="true">
-                     <connection-url>jdbc:mysql://${env.UNIFIEDPUSH_PORT_3306_TCP_ADDR}:${env.UNIFIEDPUSH_PORT_3306_TCP_PORT}/${env.UNIFIEDPUSH_ENV_MYSQL_DATABASE}?useUnicode=true&amp;characterEncoding=UTF-8</connection-url>
+                     <connection-url>jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}/${env.MYSQL_DATABASE}?useUnicode=true&amp;characterEncoding=UTF-8</connection-url>
                      <driver>mysql</driver>
                      <security>
-                       <user-name>${env.UNIFIEDPUSH_ENV_MYSQL_USER}</user-name>
-                       <password>${env.UNIFIEDPUSH_ENV_MYSQL_PASSWORD}</password>
+                       <user-name>${env.MYSQL_USER}</user-name>
+                       <password>${env.MYSQL_PASSWORD}</password>
                      </security>
                      <validation>
                          <check-valid-connection-sql>SELECT 1</check-valid-connection-sql>
@@ -170,11 +170,11 @@
                      </pool>
                  </datasource>
                  <datasource jndi-name="java:jboss/datasources/KeycloakDS" enabled="true" use-java-context="true" pool-name="KeycloakDS" use-ccm="true">
-                     <connection-url>jdbc:mysql://${env.KEYCLOAK_PORT_3306_TCP_ADDR}:${env.KEYCLOAK_PORT_3306_TCP_PORT}/${env.KEYCLOAK_ENV_MYSQL_DATABASE}?useUnicode=true&amp;characterEncoding=UTF-8</connection-url>
+                     <connection-url>jdbc:mysql://${env.MYSQL_PORT_3306_TCP_ADDR}:${env.MYSQL_PORT_3306_TCP_PORT}/${env.MYSQL_DATABASE}?useUnicode=true&amp;characterEncoding=UTF-8</connection-url>
                      <driver>mysql</driver>
                      <security>
-                       <user-name>${env.KEYCLOAK_ENV_MYSQL_USER}</user-name>
-                       <password>${env.KEYCLOAK_ENV_MYSQL_PASSWORD}</password>
+                       <user-name>${env.MYSQL_USER}</user-name>
+                       <password>${env.MYSQL_PASSWORD}</password>
                      </security>
                      <validation>
                          <check-valid-connection-sql>SELECT 1</check-valid-connection-sql>

--- a/wildfly/unifiedpush-wildfly/Dockerfile
+++ b/wildfly/unifiedpush-wildfly/Dockerfile
@@ -1,7 +1,11 @@
 # Use latest aerogear/wildfly image as the base
-FROM aerogear/wildfly
+FROM rhmap/wildfly
 MAINTAINER Bruno Oliveira <bruno@aerogear.org>
 
+RUN mkdir -p /opt/jboss/wildfly/standalone/data && \
+    mkdir -p /opt/jboss/wildfly/standalone/tmp/vfs/temp && \
+    mkdir -p /opt/jboss/wildfly/standalone/log && \
+    chmod -R 777 /opt/jboss/wildfly/standalone
 
 # Download Aerogear distribution
 ENV UPSVER=1.1.3.Final

--- a/wildfly/unifiedpush-wildfly/liquibase.properties
+++ b/wildfly/unifiedpush-wildfly/liquibase.properties
@@ -1,4 +1,4 @@
-url=jdbc:mysql://unifiedpush:3306/unifiedpush
+url=jdbc:mysql://mysql:3306/unifiedpush
 driver=com.mysql.jdbc.Driver
 username=unifiedpush
 password=unifiedpush


### PR DESCRIPTION
Tested with OSE3.2. See also https://github.com/fheng/fh-openshift-templates/pull/216 for OpenShift 3 template.

Some tweaks:

* Renamed the mysql service to `mysql` rather than `unifiedpush` so that the image works OOTB with the  OS MySQL Ephemeral / Persistant templates