### PR TITLE
Adding entrypoint to allow System properties to be passed in

### DIFF
--- a/wildfly/unifiedpush-wildfly-dev/Dockerfile
+++ b/wildfly/unifiedpush-wildfly-dev/Dockerfile
@@ -64,3 +64,8 @@ RUN cp auth-server/target/*.war $JBOSS_HOME/standalone/deployments
 
 # Copy binary file for the UnifiedPush server to deployments folder
 RUN cp ups-wildfly/target/*.war $JBOSS_HOME/standalone/deployments
+
+# copy and run startup script
+COPY entrypoint.sh /opt/
+ENTRYPOINT ["/opt/entrypoint.sh"]
+

--- a/wildfly/unifiedpush-wildfly-dev/entrypoint.sh
+++ b/wildfly/unifiedpush-wildfly-dev/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+# launch wildfly
+exec /opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 $@


### PR DESCRIPTION
Adding entypoint to allow passing in `"-Dsystem=properties"` to the docker run command 