### PR TITLE
Adding latest 1.2.0.Final bundle

### DIFF
--- a/wildfly/unifiedpush-wildfly/Dockerfile
+++ b/wildfly/unifiedpush-wildfly/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Matthias Wessendorf <matzew@apache.org>
 
 
 # Download Aerogear distribution
-ENV UPSVER=1.2.0-rc.2
+ENV UPSVER=1.2.0.Final
 ENV UPSDIST=/opt/aerogear-unifiedpush-server-$UPSVER
 
 RUN curl -L -o /opt/aerogear-unifiedpush-server-$UPSVER-dist.tar.gz https://github.com/aerogear/aerogear-unifiedpush-server/releases/download/$UPSVER/aerogear-unifiedpush-server-$UPSVER-dist.tar.gz


### PR DESCRIPTION
How to test is discovered here:

* Build the image from the branch, like here:
https://github.com/aerogear/dockerfiles/tree/master/wildfly/unifiedpush-wildfly#building-the-image-alternative

* Run it all together:
https://github.com/aerogear/dockerfiles/tree/master/wildfly/unifiedpush-wildfly#running-the-image

**NOTE:** you need a Keycloak realm, for UPS. A demo realm is provided in the ups repo, here:
https://github.com/aerogear/aerogear-unifiedpush-server/tree/master/docker-compose/development/ups-realm