### PR TITLE
Do not add Keycloak server port when default are used

### DIFF
--- a/wildfly/unifiedpush-wildfly/entrypoint.sh
+++ b/wildfly/unifiedpush-wildfly/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -d /keys ];then
     export SERVER_PASSWORD=$(head -c 2000 /dev/urandom | tr -dc a-z0-9A-Z | head -c 256)
     echo "custom certificates directory found - replacing default self signed generated certificate"
     mv $JBOSS_HOME/standalone/configuration/certs/server.$DOMAIN.keystore $JBOSS_HOME/standalone/configuration/certs/selfsigned.keystore
-    
+
     openssl pkcs12 -export -name server.$DOMAIN -in /keys/certificate.crt -inkey /keys/privatekey.key -out $JBOSS_HOME/standalone/configuration/certs/server.$DOMAIN.keystore -passout env:SERVER_PASSWORD
     sed -i "s/keystore-password=\".*\" a/keystore-password=\"$SERVER_PASSWORD\" a/g" $JBOSS_HOME/standalone/configuration/standalone.xml
 else
@@ -21,5 +21,14 @@ fi
 
 # launch wildfly
 echo "launching wildfly"
-exec /opt/jboss/wildfly/bin/standalone.sh -Dups.realm.name=aerogear -Dups.auth.server.url=http://${KEYCLOAK_SERVICE_HOST}:${KEYCLOAK_SERVICE_PORT}/auth -b 0.0.0.0 $@
 
+if [ "x$KEYCLOAK_SERVICE_PORT" = "x80" ]; then
+  echo "Launching Aerogear with Keycloak on http default port..."
+  exec /opt/jboss/wildfly/bin/standalone.sh -Dups.realm.name=aerogear -Dups.auth.server.url=http://${KEYCLOAK_SERVICE_HOST}/auth -b 0.0.0.0 $@
+else if [ "x$KEYCLOAK_SERVICE_PORT" = "x443" ]; then
+  echo "Launching Aerogear with Keycloak on https default 80 port..."
+  exec /opt/jboss/wildfly/bin/standalone.sh -Dups.realm.name=aerogear -Dups.auth.server.url=https://${KEYCLOAK_SERVICE_HOST}/auth -b 0.0.0.0 $@
+else
+  echo "Default launching of Aerogear..."
+  exec /opt/jboss/wildfly/bin/standalone.sh -Dups.realm.name=aerogear -Dups.auth.server.url=http://${KEYCLOAK_SERVICE_HOST}:${KEYCLOAK_SERVICE_PORT}/auth -b 0.0.0.0 $@
+fi

--- a/wildfly/unifiedpush-wildfly/entrypoint.sh
+++ b/wildfly/unifiedpush-wildfly/entrypoint.sh
@@ -22,10 +22,10 @@ fi
 # launch wildfly
 echo "launching wildfly"
 
-if [ "x$KEYCLOAK_SERVICE_PORT" = "x80" ]; then
+if [ "x$KEYCLOAK_SERVICE_PORT" == "x80" ]; then
   echo "Launching Aerogear with Keycloak on http default port..."
   exec /opt/jboss/wildfly/bin/standalone.sh -Dups.realm.name=aerogear -Dups.auth.server.url=http://${KEYCLOAK_SERVICE_HOST}/auth -b 0.0.0.0 $@
-else if [ "x$KEYCLOAK_SERVICE_PORT" = "x443" ]; then
+elif [ "x$KEYCLOAK_SERVICE_PORT" == "x443" ]; then
   echo "Launching Aerogear with Keycloak on https default 80 port..."
   exec /opt/jboss/wildfly/bin/standalone.sh -Dups.realm.name=aerogear -Dups.auth.server.url=https://${KEYCLOAK_SERVICE_HOST}/auth -b 0.0.0.0 $@
 else


### PR DESCRIPTION
The `entrypoint.sh` script always add the `KEYCLOAK_SERVICE_PORT` in UPS realm URL, even if it's the default ones.

This is correct but causes issue: the route leads to external Keycloak that issues a token. The later verification of token will more likely fail because the token was issued going through `http://sso.server/xxx` and not `http://sso.server:80/xxx`. Same things happen for https scheme.

So just ignore adding a port to the UPS realm property when port is 80 or 443.