### PR TITLE
Using latest postgres JDBC 4.2 driver, for java8+

### DIFF
--- a/wildfly/Dockerfile
+++ b/wildfly/Dockerfile
@@ -10,9 +10,9 @@ RUN yum install -y unzip wget && yum -q clean all
 
 ## PostgreSQL
 ENV psql_module_dir=$JBOSS_HOME/modules/org/postgresql/main/
-ENV psql_connector_jar=postgresql-9.2-1004-jdbc41.jar
+ENV psql_connector_jar=postgresql-jdbc.jar
 RUN mkdir -p ${psql_module_dir}
-RUN wget -O ${psql_connector_jar} http://search.maven.org/remotecontent\?filepath\=org/postgresql/postgresql/9.2-1004-jdbc41/postgresql-9.2-1004-jdbc41.jar
+RUN wget -O ${psql_connector_jar} http://search.maven.org/remotecontent\?filepath\=org/postgresql/postgresql/42.2.2/postgresql-42.2.2.jar
 RUN mv ${psql_connector_jar} ${psql_module_dir}
 COPY configuration/xml/psql-module.xml ${psql_module_dir}/module.xml
 

--- a/wildfly/configuration/xml/psql-module.xml
+++ b/wildfly/configuration/xml/psql-module.xml
@@ -17,7 +17,7 @@
 -->
 <module xmlns="urn:jboss:module:1.0" name="org.postgresql">
     <resources>
-        <resource-root path="postgresql-9.2-1004-jdbc41.jar"/>
+        <resource-root path="postgresql-jdbc.jar"/>
     </resources>
     <dependencies>
         <module name="javax.api"/>


### PR DESCRIPTION
As per suggestion from Jesper, I am updating to the latest JDBC (4.2) driver for Postgres.

The version scheme for the drive has been changed, and the version number now _thankfully_ no longer implies any JDBC or Psql server versions. See here:
https://jdbc.postgresql.org/documentation/faq.html#versioning