### PR TITLE
Update to 2 0 2

### DIFF
--- a/wildfly/unifiedpush-wildfly-plain/Dockerfile
+++ b/wildfly/unifiedpush-wildfly-plain/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Matthias Wessendorf <matzew@apache.org>
 
 
 # Download Aerogear distribution
-ENV UPSVER=2.0.1.Final
+ENV UPSVER=2.0.2.Final
 ENV UPSDIST=/opt/aerogear-unifiedpush-server-$UPSVER
 
 RUN curl -L -o /opt/aerogear-unifiedpush-server-$UPSVER-dist.tar.gz https://github.com/aerogear/aerogear-unifiedpush-server/releases/download/$UPSVER/aerogear-unifiedpush-server-$UPSVER-dist.tar.gz

--- a/wildfly/unifiedpush-wildfly-plain/README.md
+++ b/wildfly/unifiedpush-wildfly-plain/README.md
@@ -46,7 +46,7 @@ $ docker run --name ups \
            -e POSTGRES_DATABASE=unifiedpush \
            -e POSTGRES_USER=unifiedpush \
            -e POSTGRES_PASSWORD=supersecret \
-           -dit aerogear/unifiedpush-wildfly-plain:2.0.1
+           -dit aerogear/unifiedpush-wildfly-plain:2.0.2
 ```
 
 **Note**: The image will run SSL by default with self signed certificates being automatically generated.    

--- a/wildfly/unifiedpush-wildfly/Dockerfile
+++ b/wildfly/unifiedpush-wildfly/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Matthias Wessendorf <matzew@apache.org>
 
 
 # Download Aerogear distribution
-ENV UPSVER=2.0.1.Final
+ENV UPSVER=2.0.2.Final
 ENV UPSDIST=/opt/aerogear-unifiedpush-server-$UPSVER
 
 RUN curl -L -o /opt/aerogear-unifiedpush-server-$UPSVER-dist.tar.gz https://github.com/aerogear/aerogear-unifiedpush-server/releases/download/$UPSVER/aerogear-unifiedpush-server-$UPSVER-dist.tar.gz

--- a/wildfly/unifiedpush-wildfly/README.md
+++ b/wildfly/unifiedpush-wildfly/README.md
@@ -57,7 +57,7 @@ $ docker run --name ups \
            -e POSTGRES_PASSWORD=unifiedpush \
            -e KEYCLOAK_SERVICE_HOST=localhost \
            -e KEYCLOAK_SERVICE_PORT=8080 \
-           -dit aerogear/unifiedpush-wildfly:2.0.0 \
+           -dit aerogear/unifiedpush-wildfly:2.0.2 \
            "-Djboss.socket.binding.port-offset=1010"
 ```
 


### PR DESCRIPTION
Use the latest 2.0.2 version of UPS which contains a fix that defaults to the admin user when no Keycloak is used.